### PR TITLE
Complete Eclipse descriptors for RX process artifacts

### DIFF
--- a/process-configuration-model/.classpath
+++ b/process-configuration-model/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>

--- a/process-metadata-annotations/.classpath
+++ b/process-metadata-annotations/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>

--- a/process-metadata-model/.classpath
+++ b/process-metadata-model/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>

--- a/process-rx-bpmn2pd/.classpath
+++ b/process-rx-bpmn2pd/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>

--- a/process-rx-module-api/.classpath
+++ b/process-rx-module-api/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>

--- a/process-rx-module/.classpath
+++ b/process-rx-module/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>

--- a/process-rx-processing/.classpath
+++ b/process-rx-processing/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>


### PR DESCRIPTION
Add the standard Devrock Eclipse classpath descriptor to the seven new Process model, API, processing and RX module projects that already carry a Java project descriptor. This makes Pom-discovered projects directly importable in Eclipse.

Verification:
- all Java-nature projects in the repository now have a classpath descriptor
- git diff check is clean
- descriptor-only change; published JAR content is unaffected