### PR TITLE
Fix root node duplication when extending an existing process definition

### DIFF
--- a/pd-expert-editor/src/tribefire/pd/editor/impl/ProcessDefinitionEditorImpl.java
+++ b/pd-expert-editor/src/tribefire/pd/editor/impl/ProcessDefinitionEditorImpl.java
@@ -64,20 +64,28 @@ public class ProcessDefinitionEditorImpl implements ProcessDefinitionEditor {
 	}
 
 	private void registerStandardNode(StandardNode node) {
-		nodes.put(String.valueOf(node.getState()), node);
+		nodes.put(stateKey(node.getState()), node);
 	}
 
 	private void registerConditionalEdge(ConditionalEdge edge) {
-		String from = String.valueOf(edge.getFrom().getState());
-		String to = String.valueOf(edge.getTo().getState());
+		String from = stateKey(edge.getFrom().getState());
+		String to = stateKey(edge.getTo().getState());
 		String name = edge.getName().value();
 		conditionalEdges.put(new ConditionalEdgeKey(from, to, name), edge);
 	}
 
 	private void registerEdge(Edge edge) {
-		String from = edge.getFrom().getState() != null ? String.valueOf(edge.getFrom().getState()) : null;
-		String to = String.valueOf(edge.getTo().getState());
+		String from = stateKey(edge.getFrom().getState());
+		String to = stateKey(edge.getTo().getState());
 		edges.put(Pair.of(from, to), edge);
+	}
+
+	/**
+	 * The root node's state is null and lookups (e.g. {@link #acquireNode(String)} via rootNode()) use null keys, so
+	 * registration must preserve null rather than mapping it to the string "null" as String.valueOf would.
+	 */
+	private static String stateKey(Object state) {
+		return state != null ? String.valueOf(state) : null;
 	}
 
 	private static class ConditionalEdgeKey {


### PR DESCRIPTION
Problem: when extending an existing process definition, ProcessDefinitionEditorImpl registered existing nodes under String.valueOf of their state, which maps the root node state null to the four-letter string null. Lookups via rootNode, acquireNode and edge use a real null key instead, so the registered root node was missed and acquireNode silently created a second root node with a fresh globalId. Root edges added afterwards attach to the duplicate, while unlinkEdge detaches edges from the original root, leaving it edge-less. At runtime the process engine resolves the start node by state == null and non-deterministically picks one of the two roots, so processes sometimes start on the edge-less root and do nothing. Looks like a race condition but is deterministic data corruption. Fix: register nodes, edges and conditional edges through a null-preserving stateKey helper so registration keys match lookup keys. Note: commit 37ad020 already fixed this for the from key of plain edges, this PR covers the remaining spots.